### PR TITLE
Updated exodus link in first article

### DIFF
--- a/content/news/2021-05-06/6/index.md
+++ b/content/news/2021-05-06/6/index.md
@@ -4,7 +4,7 @@ date: 2021-05-06T07:20:28+00:00
 slug: "no-more-trackers-according-to-the-latest-exodus-privacy-report"
 ---
 
-No more trackers according to the latest [Exodus Privacy Report](https://reports.exodus-privacy.eu.org/en/reports/314366/)!
+No more trackers according to the latest [Exodus Privacy Report](https://reports.exodus-privacy.eu.org/en/reports/app.organicmaps/latest/)!
 
 Install Organic Maps from:
 - [Google Play](https://play.google.com/store/apps/details?id=app.organicmaps)


### PR DESCRIPTION
- Updated exodus link to be sure users have latest exodus report.
- Same link is used in README.md in organicmaps repository and on organicmaps.app front page.
- I have check we don't have others pages in website where we have exodus link.