### PR TITLE
[style] Make dark mode background a bit lighter

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -130,7 +130,7 @@ footer {
 
 @media (prefers-color-scheme: dark) {
   body {
-    background: #000;
+    background: #121212;
     color: #bbb;
   }
 


### PR DESCRIPTION
Right now the background is pure black.

This change makes it to a light grey and thereby reduces the contrast.
This helps when reading.

It is good, as the text color already is a "darker" white.

Just thought I'll create the PR let me know what you think

Current production:
![prod](https://user-images.githubusercontent.com/37423773/206551533-3b973849-7f2e-4f00-9a5c-eca1d18f27d2.png)

With new background:
![dark](https://user-images.githubusercontent.com/37423773/206551568-c4264e89-b42c-4604-8c56-7981e59ede7c.png)
