### PR TITLE
Add flathub verification token

### DIFF
--- a/static/.well-known/org.flathub.VerifiedApps.txt
+++ b/static/.well-known/org.flathub.VerifiedApps.txt
@@ -1,0 +1,1 @@
+f73af4c1-efd9-49ef-8cd5-9b87c5cb5b17


### PR DESCRIPTION
In order to consider our application verified by flathub, flathub requires the project, to prove the ownerhsip of the project, homepage and domeain, by publish a token in a page under `/.well-known/org.flathub.VerifiedApps.txt` in our case under
https://organicmaps.app/.well-known/org.flathub.VerifiedApps.txt

This is the first step to fix:
https://github.com/organicmaps/organicmaps/issues/4793