### PR TITLE
Add taxonomies for all languages in config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -45,8 +45,14 @@ name = "Name"
 token = "Token"
 faq-menu-title = "F.A.Q"
 
+# Rest of other languages
 # Please sort all other translation sections and values in alphabetical order.
+
+# Language: de (German / Deutsch)
 [languages.de]
+taxonomies = [
+  {name = "faq", feed = false},
+]
 [languages.de.translations]
 address = "Adresse"
 back = "Zurück zu den Neuigkeiten"
@@ -58,7 +64,12 @@ install-fdroid = "Installiere Organic Maps aus F-Droid"
 language = "Deutsch"
 name = "Name"
 token = "Token"
+
+# Language: fr (French / Français)
 [languages.fr]
+taxonomies = [
+  {name = "faq", feed = false},
+]
 [languages.fr.translations]
 address = "Addresse"
 back = "Retour aux actualités"
@@ -70,7 +81,12 @@ install-fdroid = "Installer Organic Maps depuis F-Droid"
 language = "Français"
 name = "Nom"
 token = "Jeton"
+
+# Language: it (Italian / Italiano)
 [languages.it]
+taxonomies = [
+  {name = "faq", feed = false},
+]
 [languages.it.translations]
 address = "Indirizzi"
 back = "Indietro"
@@ -82,7 +98,12 @@ install-fdroid = "Installa Organic Maps da F-Droid"
 language = "Italiano"
 name = "Nome"
 token = "Token"
+
+# Language: pl (Polish / Polski)
 [languages.pl]
+taxonomies = [
+  {name = "faq", feed = false},
+]
 [languages.pl.translations]
 address = "Adres"
 back = "Powrót do Nowości"
@@ -94,6 +115,8 @@ install-fdroid = "Zainstaluj Organic Maps z F-Droid"
 language = "Polski"
 name = "Nazwa"
 token = "Token"
+
+# Language: ru (Russian / Русский)
 [languages.ru]
 taxonomies = [
   {name = "faq", feed = false},
@@ -103,6 +126,7 @@ address = "Адрес"
 back = "Назад к новостям"
 contact = "Связаться с нами"
 engines = "Поддерживаемые TTS движки"
+faq-menu-title = "Справка"
 install-appgallery = "Установите Organic Maps из Huawei AppGallery"
 install-appstore = "Установите Organic Maps из AppStore"
 install-googleplay = "Установите Organic Maps из Google Play"
@@ -110,9 +134,12 @@ install-fdroid = "Установите Organic Maps из F-Droid"
 language = "Русский"
 name = "Название"
 token = "Токен"
-faq-menu-title = "Справка"
 
+# Language: tr (Turkish / Türkçe)
 [languages.tr]
+taxonomies = [
+  {name = "faq", feed = false},
+]
 [languages.tr.translations]
 address = "Adres"
 back = "Haberlere geri dön"
@@ -124,7 +151,12 @@ install-fdroid = "Organic Maps'i F-Droid'den İndir"
 language = "Türkçe"
 name = "İsim"
 token = "Token"
+
+# Language: id (Indonesian / Bahasa Indonesia)
 [languages.id]
+taxonomies = [
+  {name = "faq", feed = false},
+]
 [languages.id.translations]
 address = "Alamat"
 back = "Kembali ke Berita"
@@ -136,7 +168,12 @@ install-fdroid = "Instal Peta Organik dari F-Droid"
 language = "Bahasa Indonesia"
 name = "Nama"
 token = "Token"
+
+# Language: cs (Czech / Čeština)
 [languages.cs]
+taxonomies = [
+  {name = "faq", feed = false},
+]
 [languages.cs.translations]
 address = "Adresa"
 back = "Zpět na novinky"
@@ -148,6 +185,12 @@ install-fdroid = "Instalace Organic Maps z F-Droid"
 language = "Čeština"
 name = "Název"
 token = "Token"
+
+# Language: pt-BR (Portuguese (Brazil) / Português (Brazil))
+[languages.pt-BR]
+taxonomies = [
+  {name = "faq", feed = false},
+]
 [languages.pt-BR.translations]
 address = "Endereço"
 back = "Voltar às Notícias"
@@ -159,6 +202,12 @@ install-fdroid = "Instale Organic Maps a partir do F-Droid"
 language = "Português (Brazil)"
 name = "Nome"
 token = "Token"
+
+# Language: es (Spanish / Español)
+[languages.es]
+taxonomies = [
+  {name = "faq", feed = false},
+]
 [languages.es.translations]
 address = "Dirección"
 back = "Volver a Noticias"
@@ -170,6 +219,12 @@ install-fdroid = "Instalar Organic Maps desde F-Droid"
 language = "Español"
 name = "Nombre"
 token = "Ficha"
+
+# Language: nl (Dutch / Nederlands)
+[languages.nl]
+taxonomies = [
+  {name = "faq", feed = false},
+]
 [languages.nl.translations]
 address = "Adres"
 back = "Terug naar Nieuws"
@@ -181,6 +236,12 @@ install-fdroid = "Installeer Organic Maps op F-Droid"
 language = "Dutch"
 name = "Naam"
 token = "Token"
+
+# Language: eu (Basque / Euskara)
+[languages.eu]
+taxonomies = [
+  {name = "faq", feed = false},
+]
 [languages.eu.translations]
 address = "Helbidea"
 back = "Back to News"
@@ -192,6 +253,12 @@ install-fdroid = "Install Organic Maps from F-Droid"
 language = "Euskara"
 name = "Izena"
 token = "token"
+
+# Language: hu (Hungarian / Magyar)
+[languages.hu]
+taxonomies = [
+  {name = "faq", feed = false},
+]
 [languages.hu.translations]
 address = "Cím"
 back = "Vissza a Hírekhez"
@@ -203,6 +270,12 @@ install-fdroid = "Telepítse az Organic Maps-et az F-Droidról"
 language = "Magyar"
 name = "Név"
 token = "Token"
+
+# Language: hi (Hindi / हिंदी)
+[languages.hi]
+taxonomies = [
+  {name = "faq", feed = false},
+]
 [languages.hi.translations]
 address = "पता"
 back = "ख़बरों पर वापस जाएं"
@@ -214,6 +287,12 @@ install-fdroid = "F-Droid से ऑर्गेनिक मैप्स इं
 language = "हिंदी"
 name = "नाम"
 token = "टोकन/Token"
+
+# Language: uk (Ukranian / Українська)
+[languages.uk]
+taxonomies = [
+  {name = "faq", feed = false},
+]
 [languages.uk.translations]
 address = "Адреса"
 back = "Назад до Новин"
@@ -225,6 +304,12 @@ install-fdroid = "Встановіть Organic Maps з F-Droid"
 language = "Українська"
 name = "Назва"
 token = "Токен"
+
+# Language: ca (Catalonian / Català)
+[languages.ca]
+taxonomies = [
+  {name = "faq", feed = false},
+]
 [languages.ca.translations]
 address = "Adreça"
 back = "Torna a Notícies"
@@ -236,7 +321,12 @@ install-fdroid = "Instal·leu l’Organic Maps des del F-Droid"
 language = "Català"
 name = "Nom"
 token = "Testimoni"
+
+# Language: zh-CN (Chinese / 英语)
 [languages.zh-CN]
+taxonomies = [
+  {name = "faq", feed = false},
+]
 [languages.zh-CN.translations]
 address = "地址"
 back = "返回新闻"
@@ -248,6 +338,12 @@ install-fdroid = "从 F-Droid 安装有机地图"
 language = "英语"
 name = "姓名"
 token = "令牌"
+
+# Language: sv (Swedish / Svenska)
+[languages.sv]
+taxonomies = [
+  {name = "faq", feed = false},
+]
 [languages.sv.translations]
 address = "Adress"
 back = "Tillbaka till nyheter"
@@ -259,6 +355,12 @@ install-fdroid = "Installera Organic Maps från F-Droid"
 language = "Svenska"
 name = "Namn"
 token = "Token"
+
+# Language: mr (Marathi / मराठी)
+[languages.mr]
+taxonomies = [
+  {name = "faq", feed = false},
+]
 [languages.mr.translations]
 address = "पत्ता"
 back = "बातम्यांवर परता"
@@ -270,6 +372,12 @@ install-fdroid = "F-Droid द्वारे Organic Maps स्थापित 
 language = "मराठी"
 name = "नाव"
 token = "Token"
+
+# Language: zh-Hans (Simplified Chinese / मराठी)
+[languages.zh-Hans]
+taxonomies = [
+  {name = "faq", feed = false},
+]
 [languages.zh-Hans.translations]
 address = "地址"
 back = "返回到新闻"
@@ -281,6 +389,12 @@ install-fdroid = "从F-Droid安装Organic Maps"
 language = "简体中文"
 name = "名称"
 token = "令牌"
+
+# Language: oc (Occitan / Occitan)
+[languages.oc]
+taxonomies = [
+  {name = "faq", feed = false},
+]
 [languages.oc.translations]
 address = "Address"
 back = "Back to News"
@@ -292,6 +406,12 @@ install-fdroid = "Installar Mapas Organicas de F-Droid"
 language = "Occitan"
 name = "Nom"
 token = "geton"
+
+# Language: af (Afrikaans / Afrikaans)
+[languages.af]
+taxonomies = [
+  {name = "faq", feed = false},
+]
 [languages.af.translations]
 address = "Adres"
 back = "Terug na nuus"
@@ -303,6 +423,12 @@ install-fdroid = "Installeer Organic Maps vanaf F-Droid"
 language = "Afrikaans"
 name = "Naam"
 token = "Teken"
+
+# Language: ar (Arabic / العربية)
+[languages.ar]
+taxonomies = [
+  {name = "faq", feed = false},
+]
 [languages.ar.translations]
 address = "العنوان"
 back = "العودة إلى الأخبار"


### PR DESCRIPTION
Added code in `config.toml` for all languages:
```
# Language: country-code (English language name / Locale language name)
taxonomies = [
  {name = "faq", feed = false},
]
```
These languages shall be ordered in `config.toml` file in future PRs...