### PR TITLE
Actualize the list of crypto wallets

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -29,6 +29,19 @@ paths = "safe"
 
 [extra]
 stripe = "https://donate.organicmaps.app/"
+ada = "addr1qxh59080ujswxuzapzrdvuzpglfktg09gq9q7dxpdl7jfka0g27wle9qudc96zyx6ecyz37nvks72sq2pu6vzmlayndsj02qhw"
+algo = "3UZXZEPGFAM7E74IO32Y7O6KOY3E7NNNJVBV4GFS5UWQQSY7AIM5PK7C2E"
+bch = "qqcjkzf7nlgvhng5vhq7n7hjrcdqccyqlq9h7gq4xw"
+bnb = "bnb1c8vmnqqhqc6lcajpzvuy4ss5dw3vjc7tc5q8zd"
+btc = "bc1qjkq3tpy2gutsfdlcvys8slkempywk230u8rc8u"
+doge = "DRdtRetmiSFHLkorNHyf4nL2MT375Xkmrm"
+eth = "0x1D59bBe5d4332e34116DccDE5c1a8c736E1C2810"
+ltc = "LfmSZ5yKBf17WwahZK9NEq5w2FLVap4Ctw"
+sol = "Eyv43vXxmSshDPReJnfMtrDspugsVR3S6PzJV38rMAZE"
+trx = "TNQGZwAUCpwy1cuVSyu1vc6AT19nsmWqRF"
+xmr = "44YsnJihPB7TBucb17WiXDde7qguUwNmGKFSsyrFqWheEaDKQRtMfGcEU54aJ8PeQNgV7Q9uBWB5CTcvKSMEH4QtE6BT1cm"
+xrp = "rQ5hNeQKqiDVyNGgX9qhv5hdDETnsqNgy"
+zec = "t1djHnDg8yGfn6vLPrYgejUFf2ZCF4WMmkp"
 
 # Default English translation
 [translations]

--- a/templates/shortcodes/crypto_table.md
+++ b/templates/shortcodes/crypto_table.md
@@ -2,43 +2,19 @@
 
 {{ trans(key='name', lang=lang) }} | {{ trans(key='token', lang=lang) }} | {{ trans(key='address', lang=lang) }}
 :-------------|:-----|:----------------------------------------------------------
-Algorand      | ALGO | 3UZXZEPGFAM7E74IO32Y7O6KOY3E7NNNJVBV4GFS5UWQQSY7AIM5PK7C2E
-Avalanche C/ETH | AVAX | 0x1D59bBe5d4332e34116DccDE5c1a8c736E1C2810
-Binance Coin/BNB | BNB  | bnb1c8vmnqqhqc6lcajpzvuy4ss5dw3vjc7tc5q8zd
-Binance Coin/BSC | BSC  | 0x1D59bBe5d4332e34116DccDE5c1a8c736E1C2810
-Binance USD/ETH |BUSD | 0x1D59bBe5d4332e34116DccDE5c1a8c736E1C2810
-Bitcoin       | BTC  | bc1qjkq3tpy2gutsfdlcvys8slkempywk230u8rc8u
-Bitcoin Cash  | BCH  | qqcjkzf7nlgvhng5vhq7n7hjrcdqccyqlq9h7gq4xw
-Cardano       | ADA  | addr1qxh59080ujswxuzapzrdvuzpglfktg09gq9q7dxpdl7jfka0g27wle9qudc96zyx6ecyz37nvks72sq2pu6vzmlayndsj02qhw
-Chainlink/ETH | LINK | 0x1D59bBe5d4332e34116DccDE5c1a8c736E1C2810
-Chainlink/SOL | LINK | Eyv43vXxmSshDPReJnfMtrDspugsVR3S6PzJV38rMAZE
-Cosmos        | ATOM | cosmos1jurqcft6vf8gah8lpyz53ue9qf5gz2rfy8wfla
-Dash          | DASH | XgWTXGVCNEVVEkL9DQutscjcs6zvDUgccf
-Dai/ETH       | DAI  | 0x1D59bBe5d4332e34116DccDE5c1a8c736E1C2810
-Dogecoin      | DOGE | DRdtRetmiSFHLkorNHyf4nL2MT375Xkmrm
-eCash         | XEC  | ecash:qpy6c5050vyste69tph2xmmqjchwldvggg7pe99937
-Ethereum      | ETH  | 0x1D59bBe5d4332e34116DccDE5c1a8c736E1C2810
-Fantom/ETH    | FTM  | 0x1D59bBe5d4332e34116DccDE5c1a8c736E1C2810
-Filecoin      | FIL  | f1s4n3oog2d3swxgdqz7llo47pdfxu2ykvvptapiq
-IOTA/BSC/ETH  | MIOTA| 0x1D59bBe5d4332e34116DccDE5c1a8c736E1C2810 
-Litecoin      | LTC  | LfmSZ5yKBf17WwahZK9NEq5w2FLVap4Ctw
-Maps.Me/ETH   | MAPS | 0x1D59bBe5d4332e34116DccDE5c1a8c736E1C2810
-MAPS/SOL      | MAPS | Eyv43vXxmSshDPReJnfMtrDspugsVR3S6PzJV38rMAZE
-Monero        | XMR  | 44YsnJihPB7TBucb17WiXDde7qguUwNmGKFSsyrFqWheEaDKQRtMfGcEU54aJ8PeQNgV7Q9uBWB5CTcvKSMEH4QtE6BT1cm
-Nano          | XNO  | nano_3udk4q9nne76kkrdgbwkyugwb5r6kg48oujbccoian96xtgkhna37bg5d1qp
-NEO           | NEO  | ASqXj9MJFeytv74xE1UPmJoCZTgRz39Keu
-Polkadot      | DOT  | 15yRQT2m3wS6yGuAbkxgMNMGZvXktp63ZrgmGG6QYYyoEQiV
-Polygon/ETH   | MATIC| 0x1D59bBe5d4332e34116DccDE5c1a8c736E1C2810
-Shiba Inu/ETH | SHIB | 0x1D59bBe5d4332e34116DccDE5c1a8c736E1C2810
-Solana        | SOL  | Eyv43vXxmSshDPReJnfMtrDspugsVR3S6PzJV38rMAZE
-Status/ETH    | SNT  | 0x1D59bBe5d4332e34116DccDE5c1a8c736E1C2810
-Stellar       | XLM  | GBRYVRKX6MOU5IO6QWD4CDULBX32F5B5HCQWQYLFEFQZHRTVNTUKM6IF
-Terra         | LUNA | terra1mx695aqeae5rf9etsvdhr48j9lhtgjsc69khtm
-Tether/ETH    | USDT | 0x1D59bBe5d4332e34116DccDE5c1a8c736E1C2810
-Tether/Tron   | USDT | TNQGZwAUCpwy1cuVSyu1vc6AT19nsmWqRF
-Tezos         | XTZ  | tz1dHBNqXUrYzHHW2AUCL6WDP6fFvfiBZwPU
-Tron          | TRX  | TNQGZwAUCpwy1cuVSyu1vc6AT19nsmWqRF
-Uniswap/ETH   | UNI  | 0x1D59bBe5d4332e34116DccDE5c1a8c736E1C2810
-USD Coin/ETH  | USDC | 0x1D59bBe5d4332e34116DccDE5c1a8c736E1C2810
-XRP           | XRP  | rQ5hNeQKqiDVyNGgX9qhv5hdDETnsqNgy
-Zcash         | ZEC  | t1djHnDg8yGfn6vLPrYgejUFf2ZCF4WMmkp
+Bitcoin       | BTC  | [{{ config.extra.btc }}](bitcoin:{{ config.extra.btc }}?message=Donation)
+Ethereum      | ETH  | [{{ config.extra.eth }}](ethereum:{{ config.extra.eth }})
+Tether/ERC20  | USDT | {{ config.extra.eth }}
+Tron          | TRX  | [{{ config.extra.trx }}](tron:{{ config.extra.trx }})
+Tether/TRC20  | USDT | {{ config.extra.trx }}
+Litecoin      | LTC  | [{{ config.extra.ltc }}](litecoin:{{ config.extra.ltc }})
+Bitcoin Cash  | BCH  | [{{ config.extra.bch }}](bitcoincash:{{ config.extra.bch }})
+Binance Coin  | BNB  | [{{ config.extra.bnb }}](bnb:{{ config.extra.bnb }})
+Algorand      | ALGO | [{{ config.extra.algo }}](algorand://{{ config.extra.algo }})
+Cardano       | ADA  | [{{ config.extra.ada }}](cardano:{{ config.extra.ada }})
+XRP           | XRP  | [{{ config.extra.xrp }}](ripple:{{ config.extra.xrp }})
+Solana        | SOL  | {{ config.extra.sol }}
+ShibaINU/ERC20| SHIB | {{ config.extra.eth }}
+Dogecoin      | DOGE | [{{ config.extra.doge }}](dogecoin:{{ config.extra.doge }})
+Monero        | XMR  | [{{ config.extra.xmr }}](monero:{{ config.extra.xmr }})
+ZCash         | ZEC  | [{{ config.extra.zec }}](zcash:{{ config.extra.zec }})


### PR DESCRIPTION
Shrink the endless crypto table by keeping only what people have actually used. The most such coins have never received a penny, but have instead confused people. Please consider donating using mainstream coins instead. We'll burn more gas trying to convert unpopular s-coins into useful stuff.

This PR also adds hyperlinks. Unfortunately, these links are not standard for the majority of coins and only work with selected wallets.