### PR TITLE
User Support Champion Wanted

### DIFF
--- a/content/contribute/user-support/_index.md
+++ b/content/contribute/user-support/_index.md
@@ -1,0 +1,35 @@
+---
+title: User Support Champion
+description: Join Organic Maps as a User Support Champion to provide expert technical support, troubleshoot issues, and enhance the user experience of our privacy-focused navigation app for drivers, hikers, and cyclists worldwide.
+template: page.html
+---
+
+Location: Remote
+
+### **About Organic Maps**
+
+Organic Maps is a privacy-focused and community-developed navigation app for drivers, hikers, and cyclists. The app features ease in navigating with privacy: no location tracking, no data collection, and no ads. Search, routing and navigation operates without a cell phone signal, ideal for distant hiking trails or locations with poor connections. Organic Maps uses the crowd-sourced map data from OpenStreetMap, with contributors all over the globe, and prioritizes community development and collaboration.
+
+### **Vision**
+
+Create a world where traveling with maps has privacy-focus by default and the top choice on the planet. Unlock the freedom to navigate easily with privacy-focused maps, powered by the community.
+
+### **Opportunity**
+
+As a User Support Champion you will be working directly with people in the community who use Organic Maps, to provide technical support and assistance with the application and website.  The community ranges from tech savvy engineers, to novice technology users. Support involves maintaining high satisfaction, resolving technical challenges, and enhancing the support experience, to ensure people have a better overall navigation experience.
+
+What you will do:
+
+* Provide support to people worldwide via email, App Store, Google Play, and Telegram.
+* Investigate, troubleshoot and diagnose technical issues for iOS and Android.
+* Maintain a strong understanding of the product and the current issues on Github.  
+* Communicate about resolutions of issues and provide guidance.  
+* Evaluate, replicate and document bugs.  
+* Collect statistics of recurring requests or bugs into GitHub Issues, and highlight feedback and insights to contributors in the community.  
+* Collaborate with contributors in product, design, engineering and others within the Organic Maps community to address issues.  
+* Author knowledge base articles for product features and FAQ's.  
+* Continuously improve the support process including scaling, issue handling, reporting, and analysis, to improve people’s support experience.
+
+### Get in Touch
+
+Your expertise and dedication will be rewarded. If you are passionate about improving the user experience and supporting our community-driven project, we’d love to hear from you. Contact us at [team@organicmaps.app](mailto:team@organicmaps.app), and let’s discuss how you can make an impact!


### PR DESCRIPTION
Are you interested in being part of tech support in a global community that is changing the way we think about navigation and privacy? As a Community Support Champion you will be working directly with people in the community who use Organic Maps, to provide technical support and assistance with the application and website. The community ranges from tech savvy engineers, to novice technology users. Support involves maintaining customer satisfaction, resolving technical challenges, and enhancing the support experience, to ensure people have a better overall navigation experience.

Your expertise and dedication will be rewarded. If you are passionate about improving the user experience and supporting our community-driven project, we'd love to hear from you. Contact us at team@organicmaps.app, and let's discuss how you can make an impact!

## 

The text was written by @oleg-rswll in October 2023 but was never published.