### PR TITLE
[faq] Android Auto only whith Play Store version

### DIFF
--- a/content/faq/app/how-to-use-android-auto/index.md
+++ b/content/faq/app/how-to-use-android-auto/index.md
@@ -10,6 +10,6 @@ extra:
   order: 20
 ---
 
-To use OM with Android Auto, you need at least an Android version 8.0 (Oreo) or later.
+To use OM with Android Auto, you need at least an Android version 8.0 (Oreo) or later. Moreover you need to download Organic Maps from the Google Play Store as Google only allows Google approved apps on Android Auto.
 
 Please check the [Android Auto website](https://www.android.com/auto/) for further details.


### PR DESCRIPTION
Added that only the Play Store version of OM works on AA. Several users were confused/had questions about this, e.g.  https://github.com/orgs/organicmaps/discussions/10130.

```
Moreover you need to download Organic Maps from
the Google Play Store as Google only allows Google
approved apps on Android Auto.
```

_related to https://github.com/organicmaps/organicmaps/issues/7066_